### PR TITLE
implementación de un helper para formatear la URL de la imagen del usuario

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "react-toastify": "10.0.6",
         "react-typed": "1.2.0",
         "sass": "1.81.0",
-        "styled-components": "^6.1.14",
+        "styled-components": "6.1.14",
         "zod": "3.23.8",
         "zustand": "5.0.1"
       },

--- a/src/components/previewUser/PreviewUser.jsx
+++ b/src/components/previewUser/PreviewUser.jsx
@@ -12,7 +12,6 @@ import { IS_MOBILE } from '../../lib/variables'
 import useCommonStore from '../../hooks/commonStore'
 import UserNotifications from '../userNotifications/UserNotifications'
 import Button from '../button/Button'
-import { PROFILE } from '@/consts/profile'
 
 const ProfileImage = dynamic(() => import('../profileImage/ProfileImage'), { ssr: false })
 const MenuMobileOptions = dynamic(() => import('./MenuMobileOptions'), { ssr: false })
@@ -26,8 +25,6 @@ const PreviewUser = () => {
     router.push('#menu')
     setStoreValue('leftMenuBar', { ...leftMenuBar, isShow: !isShowLeftMenu })
   }
-  const pictureRaw = `${picture.split('?')[0]}_${PROFILE.SIZE}${picture.split('?')[1]}`
-  console.log(picture);
   return (
     <div
       className={`

--- a/src/components/previewUser/PreviewUser.jsx
+++ b/src/components/previewUser/PreviewUser.jsx
@@ -25,7 +25,7 @@ const PreviewUser = () => {
     router.push('#menu')
     setStoreValue('leftMenuBar', { ...leftMenuBar, isShow: !isShowLeftMenu })
   }
-  
+
   return (
     <div
       className={`

--- a/src/components/previewUser/PreviewUser.jsx
+++ b/src/components/previewUser/PreviewUser.jsx
@@ -12,6 +12,7 @@ import { IS_MOBILE } from '../../lib/variables'
 import useSystemStore from '../../hooks/storeSystem'
 import UserNotifications from '../userNotifications/UserNotifications'
 import Button from '../button/Button'
+import { PROFILE } from '@/consts/profile'
 
 const ProfileImage = dynamic(() => import('../profileImage/ProfileImage'), { ssr: false })
 const MenuMobileOptions = dynamic(() => import('./MenuMobileOptions'), { ssr: false })
@@ -25,7 +26,8 @@ const PreviewUser = () => {
     router.push('#menu')
     setStoreValue('leftMenuBar', { ...leftMenuBar, isShow: !isShowLeftMenu })
   }
-
+  const pictureRaw = `${picture.split('?')[0]}_${PROFILE.SIZE}${picture.split('?')[1]}`
+  console.log(picture);
   return (
     <div
       className={`

--- a/src/components/previewUser/PreviewUser.jsx
+++ b/src/components/previewUser/PreviewUser.jsx
@@ -25,6 +25,7 @@ const PreviewUser = () => {
     router.push('#menu')
     setStoreValue('leftMenuBar', { ...leftMenuBar, isShow: !isShowLeftMenu })
   }
+  
   return (
     <div
       className={`

--- a/src/components/profileImage/ProfileImage.jsx
+++ b/src/components/profileImage/ProfileImage.jsx
@@ -2,6 +2,7 @@ import { getExperiencesSrv } from '@/services/user/userService';
 import styles from './profileImage.module.scss';
 
 import React, { useEffect, useState } from 'react';
+import { getImageSize } from '@/lib/utils';
 
 const ProfileImage = ({ className, handleClickImage, picture, progress = 0, small }) => {
   const [percentageBar, setPercentageBar] = useState(progress)
@@ -21,7 +22,7 @@ const ProfileImage = ({ className, handleClickImage, picture, progress = 0, smal
   return (
     <div className={styles.profileImageContainer} onClick={handleClickImage}>
       <picture className={`${styles.ProfileImage} ${styles[className]}`}>
-        <img src={picture || '/images/users/user1.jpg'} alt="Perfil" />
+        <img src={getImageSize(picture) || '/images/users/user1.jpg'} alt="Perfil" />
         <svg
           width="250"
           height="250"

--- a/src/consts/profile.js
+++ b/src/consts/profile.js
@@ -1,0 +1,3 @@
+export const PROFILE = {
+  IMAGE_SIZE: "100x100"
+}

--- a/src/consts/profile.js
+++ b/src/consts/profile.js
@@ -1,3 +1,6 @@
 export const PROFILE = {
-  IMAGE_SIZE: "100x100"
+  SIZES: {
+    SM: 100,
+    MD: 768,
+  }
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,3 +1,4 @@
+import { PROFILE } from '@/consts/profile';
 import cookieCutter from '@boiseitguru/cookie-cutter';
 import confetti from 'canvas-confetti';
 
@@ -222,4 +223,9 @@ export function getAccessibilityPropsTabs(tabIndex) {
     id: `full-width-tab-${tabIndex}`,
     'aria-controls': `full-width-tabpanel-${tabIndex}`,
   };
+}
+
+export function getImageSize(url, size="MD") {
+  const currentSize = PROFILE.SIZES[size]
+  return url.replace(/(\.\w+)(\?.*)?$/, `_${currentSize}x${currentSize}$1$2`);
 }


### PR DESCRIPTION
## URL de Trello
https://trello.com/c/Z6PcBgpR/50-al-guardar-la-imagen-de-perfil-se-esta-guardando-la-url-dada-por-firebase-sin-embargo-esto-despues-lo-actualiza-la-extensi%C3%B3n

## Descripción (opcional)
Se implementó una función helper que permita agregar a la URL original de la imagen cargada por el usuario, el tamaño de esta. Por defecto vendrá la MD (768px por 768px). 