### PR TITLE
Lógica para el sistema de favoritos de las tiendas aliadas

### DIFF
--- a/src/components/authorInformation/AuthorInformation.jsx
+++ b/src/components/authorInformation/AuthorInformation.jsx
@@ -1,17 +1,21 @@
 import { motion } from 'framer-motion'
 
 // Custom
-import { formatNumber } from '@/lib/utils'
 import CoinIcon from '../coinIcon/CoinIcon'
 import ProfileImage from '../profileImage/ProfileImage'
 import styles from './authorInformation.module.scss'
 import Button from '../button/Button'
 import { useIAStore } from '../ia/IAstore'
+import { postChallengeDetail } from '@/services/challenges/challenges'
+import { formatNumber } from '@/lib/utils'
 
 // Icons
 import InstagramIcon from '@mui/icons-material/Instagram';
 import WhatsAppIcon from '@mui/icons-material/WhatsApp';
 import FacebookIcon from '@mui/icons-material/Facebook';
+import useCommonStore, { loadFromLocalStorage } from '@/hooks/commonStore'
+import { useEffect, useState } from 'react'
+
 export const AuthorInformation = (props) => {
     const {
         aboutHTML,
@@ -29,6 +33,29 @@ export const AuthorInformation = (props) => {
         storeName,
         whatsapp,
     } = props?.authorInformation || {}
+    const [isFavorite, setIsFavorite] = useState(false)
+    const { setStoreValue } = useCommonStore()
+    const stored = loadFromLocalStorage("favoritesSellers") || []
+
+    useEffect(() => {
+        const exists = stored.some((item) => item.storeName === storeName)
+        setIsFavorite(exists)
+      }, [storeName])
+
+    const handleFavoriteClick = async () => {
+        let updated
+    
+        if (isFavorite) {
+          updated = stored.filter((item) => item.storeName !== storeName)
+        } else {
+          updated = [...stored, props.authorInformation]
+        }
+    
+        setStoreValue("favoritesSellers", updated)
+        setIsFavorite(!isFavorite)
+    
+        await postChallengeDetail(null, { challengeId: 11 })
+      }
 
     return <div className={`${styles.AuthorComponentPage}`} style={{ ['--backgroundImage']: `url(${pageBackground})` }}>
         <div className={styles.content}>
@@ -37,11 +64,19 @@ export const AuthorInformation = (props) => {
             <motion.div
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.9 }}
-                className={styles.namePlace}>
+                className={styles.namePlace}
+                onClick={handleFavoriteClick}
+                >
                 <img
-                    className={styles.star} src="/images/icons/star.png" />
+                  className={`${styles.star} ${isFavorite && styles.active}`} 
+                  src="/images/icons/star.png" 
+                />
                 <b>{storeName || name}</b>
-                <small style={{ color: dividerColor }}>{location}</small>
+                <small 
+                  style={{ color: dividerColor }}
+                >
+                  {location}
+                </small>
             </motion.div>
             <hr style={{ background: dividerColor }} />
             {<div className={styles.creditsGiven}>

--- a/src/components/previewUser/MenuMobileOptions.jsx
+++ b/src/components/previewUser/MenuMobileOptions.jsx
@@ -6,7 +6,7 @@ import CoinIcon from '../coinIcon/CoinIcon'
 import { slugify } from '../../lib/utils'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import useCommonStore from '../../hooks/commonStore'
+import useCommonStore, { loadFromLocalStorage } from '../../hooks/commonStore'
 import { useIAStore } from '../ia/IAstore'
 import Button from '../button/Button'
 import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
@@ -70,6 +70,8 @@ const MenuMobileOptions = () => {
     }
   };
 
+  const favoritesSellers = loadFromLocalStorage("favoritesSellers") || []
+
   return <motion.div
     animate="visible"
     className={styles.MenuOptionsComponent}
@@ -129,7 +131,7 @@ const MenuMobileOptions = () => {
           Ranking
         </Link>
       </motion.ol>
-      <motion.ol variants={item} className={styles.favoriteSeller}>
+      {/* <motion.ol variants={item} className={styles.favoriteSeller}>
         <Link href="/caribe-dev">
           <img className='br-5' src="https://firebasestorage.googleapis.com/v0/b/pikplay-72843.firebasestorage.app/o/profile%2F159%2Flogo_768x768.png?alt=media&token=2022f676-ed81-4bbb-bb5a-405d689de0cd" />
           Caribe Dev
@@ -140,7 +142,15 @@ const MenuMobileOptions = () => {
           <img className='br-5' src="/images/users/conversation_club/logo.png" />
           English Club
         </Link>
+      </motion.ol> */}
+      {favoritesSellers.map(favoriteSeller => (
+        <motion.ol key={favoriteSeller.uid} variants={item} className={styles.favoriteSeller}>
+        <Link href={`/${favoriteSeller.slug}`}>
+          <img className='br-5' src={favoriteSeller.picture} />
+          {favoriteSeller.storeName}
+        </Link>
       </motion.ol>
+      ))}
       <motion.ol variants={item} onClick={changeToSellerUser}>
         Cambiar a Seller
       </motion.ol>

--- a/src/hooks/commonStore.tsx
+++ b/src/hooks/commonStore.tsx
@@ -14,7 +14,7 @@ const initialNotification = {
 
 const initialMessageTop: string | null = null;
 
-const loadFromLocalStorage = (property) => {
+export const loadFromLocalStorage = (property) => {
   let value = null
   if (typeof window != 'undefined' && property) {
     value = localStorage.getItem(property)
@@ -36,6 +36,7 @@ const initialLoginStorage = (set) => {
 }
 
 interface CommonStoreState {
+  userLogged: any;
   setStoreValue: (property: string, value: any) => void;
 }
 


### PR DESCRIPTION
Se implementó, mediante el localstorage la lógica para almacenar las tiendas aliadas favoritas.
- Al marcarse una tienda como favorita, se hace una llamada a la API
- Las tiendas que estén marcadas como favoritas, se mostrarán en el navbar.